### PR TITLE
Rename RHTAP to Konflux CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 Enterprise Contract User Guide
 ============================
 
-Some high level documentation on how to use and configure Enterprise Contract in
-Red Hat Trusted Application Pipeline.
+Some high level documentation on how to use and configure Enterprise Contract
+with Konflux CI.
 
 Uses Asciidoc and Antora.
-
-Replaces an original [draft
-in Google Docs](https://docs.google.com/document/d/1Co61T_ii4fPQBQl2Z_GYe1lDDAFJg2z1plpIcaFderk/edit).
 
 The published version should be viewable
 [here](https://enterprisecontract.dev/docs/user-guide/main/).

--- a/modules/ROOT/pages/cli.adoc
+++ b/modules/ROOT/pages/cli.adoc
@@ -65,7 +65,7 @@ $ ec --help
 
 == Validating an image
 
-To run ec against a particular container image built by RHTAP, we use the
+To run ec against a particular container image built by Konflux, we use the
 `ec validate image` command. To see the command options you can use the
 `--help` flag, e.g.:
 
@@ -117,7 +117,7 @@ NOTE:The image used in this example was signed and attested without using Rekor.
 // This doesn't work for general users since they don't have the permissions to
 // the openshift-pipelines namespace.
 
-If you have access to the RHTAP cluster, you can extract the public key like this:
+If you have access to the Konflux cluster, you can extract the public key like this:
 
 [,shell]
 ----
@@ -130,7 +130,7 @@ xref:getting-started.adoc[Getting started...], the public key is visible in the
 logs for the pipeline run.
 
 NOTE: In the future there should be a better way to find the public key file
-for the signing secret used by Tekton Chains in the RHTAP build system.
+for the signing secret used by Tekton Chains in the Konflux build system.
 
 You can now modify the `policy.yaml` file and re-run the `ec validate image`
 command to try different policy configurations. See
@@ -138,5 +138,5 @@ xref:ecc:ROOT:index.adoc[the configuration docs] for more information on the
 `policy.yaml` file, or take a look at the examples
 link:https://github.com/enterprise-contract/config[here].
 
-See also the how-to on xref:reproducing-an-rhtap-report.adoc[reproducing the Enterprise Contract output from an RHTAP
+See also the how-to on xref:reproducing-an-rhtap-report.adoc[reproducing the Enterprise Contract output from a Konflux
 integration test].

--- a/modules/ROOT/pages/configuration.adoc
+++ b/modules/ROOT/pages/configuration.adoc
@@ -24,9 +24,9 @@ image::c64db6a88c99447507fb87e42c966fda.png[]
 TIP: Notice that the public key used to verify both the signed images and the
 signed attestations created by Tekton Chains is available in the YAML output
 also. This public key is useful if you want to use Enterprise Contract outside the
-RHTAP cluster as described in xref:cli.adoc[here].
+Konflux cluster as described xref:cli.adoc[here].
 
-== Modifying the Enterprise Contract configuration used in RHTAP
+== Modifying the Enterprise Contract configuration used in Konflux
 
 To change which configuration is used by the Enterprise Contract integration
 test, it is necessary to modify the applicable "IntegrationTestScenario"

--- a/modules/ROOT/pages/cosign.adoc
+++ b/modules/ROOT/pages/cosign.adoc
@@ -1,9 +1,10 @@
 
-= Using Cosign to verify RHTAP build signatures & attestations
+= Using Cosign to verify Konflux build signatures & attestations
 
 In this section we'll provide examples showing how to use cosign to verify
-signatures and attestations for builds created by Red Hat Trusted Application
-Pipeline, RHTAP.
+signatures and attestations for builds created by [Konflux
+CI](https://github.com/konflux-ci), formerly [Red Hat App
+Studio](https://github.com/redhat-appstudio).
 
 For detailed information on Cosign refer to the
 link:https://docs.sigstore.dev/cosign/overview/[official documentation].
@@ -12,8 +13,8 @@ This document assumes cosign version 2.
 
 == Introduction
 
-RHTAP uses link:https://tekton.dev/docs/chains/[Tekton Chains] to sign the
-images created by RHTAP build pipelines, and to create signed attestations
+Konflux uses link:https://tekton.dev/docs/chains/[Tekton Chains] to sign the
+images created by Konflux build pipelines, and to create signed attestations
 that include details about the Tekton pipeline run that created the image.
 
 It's possible to verify these signatures and view the attestation directly
@@ -24,7 +25,7 @@ the image that was created, and that you have access to that repository.
 == Obtain image reference
 
 When validating an image, from an application component for example, it is
-recommended to always use an image reference includes a digest. The RHTAP
+recommended to always use an image reference includes a digest. The Konflux
 build pipelines emit results that contain this information. They are called
 `IMAGE_URL` and `IMAGE_DIGEST`. Combine the two with the `@` to create the
 image reference with a digest. For example, if
@@ -37,7 +38,7 @@ It is also possible to obtain the image reference from the Web UI.
 
 == Obtain public key
 
-Currently, RHTAP uses a long-lived key for signing. This key can be retrieved
+Currently, Konflux uses a long-lived key for signing. This key can be retrieved
 from the corresponding member cluster:
 
 [.console-input]
@@ -49,7 +50,7 @@ kubectl get -n openshift-pipelines secret public-key -o json | jq -r '.data."cos
 == Validating the image
 
 The first step in validating an image is verifying it has been signed with the
-proper signature. This is to ensure the image was indeed built in a RHTAP
+proper signature. This is to ensure the image was indeed built in a Konflux
 build pipeline.
 
 [.console-input]
@@ -67,12 +68,12 @@ The following checks were performed on each of these signatures:
 [{"critical":{"identity":{"docker-reference":"quay.io/redhat-appstudio/user-workload"},"image":{"docker-manifest-digest":"sha256:de1c78cd8321ec999187dfc95ed5470b4a5b2bf5121a2482dba7b5965868253d"},"type":"cosign container image signature"},"optional":null}]
 ----
 
-NOTE: At the moment, RHTAP does not use a transparency log like Rekor. Starting
+NOTE: At the moment, Konflux does not use a transparency log like Rekor. Starting
 with version 2, cosign requires the explicit flag `--insecure-ignore-tlog` to
 not use Rekor during the verification process.
 
 Next, validate that the image contains the expected SLSA Provenance attestations.
-Images built by the RHTAP build pipeline will have two of them. One representing
+Images built by the Konflux build pipeline will have two of them. One representing
 the Tekton TaskRun in which the image was built, and one representing the Tekton
 PipelineRun that contains the previously mentioned TaskRun. The attestation for
 the PipelineRun is useful in understanding all the steps used when building the
@@ -101,7 +102,7 @@ contents of the attestations.
 At the moment, the Software Bill of Materials (SBOM) attachment is not signed.
 However, it can be inspected via the `cosign download sbom` command. It is
 important to note that this command offers no guarantee that the SBOM attachment
-was produced as part of the RHTAP build pipeline.
+was produced as part of the Konflux build pipeline.
 
 [source, bash]
 ----
@@ -113,7 +114,7 @@ Found SBOM of media type: application/vnd.cyclonedx+json
 
 The snippet above saves the SBOM into a file named `sbom.json`. This file could
 also be used as input to a policy engine. However, beware that since it is not
-signed, it is susceptible to modifications outside the RHTAP build pipeline.
+signed, it is susceptible to modifications outside the Konflux build pipeline.
 
 == Using `cosign tree`
 

--- a/modules/ROOT/pages/custom-config.adoc
+++ b/modules/ROOT/pages/custom-config.adoc
@@ -1,7 +1,7 @@
 
 = Using custom configuration
 
-== Accessing the RHTAP cluster using `oc` or `kubectl`
+== Accessing the Konflux cluster using `oc` or `kubectl`
 
 include::partial$oc_login.adoc[]
 
@@ -148,7 +148,7 @@ could do this for example:
 
 [,shell]
 ----
-$ git commit -m "Trigger an RHTAP rebuild" --allow-empty && git push origin main
+$ git commit -m "Trigger a Konflux rebuild" --allow-empty && git push origin main
 ----
 
 For testing and debugging Enterprise Contract policies conveniently on your

--- a/modules/ROOT/pages/custom-data.adoc
+++ b/modules/ROOT/pages/custom-data.adoc
@@ -267,7 +267,7 @@ Rather than skip the test, let's imagine you want to modify the behavior of the
 `step_image_registries.disallowed_task_step_image` rule to allow images from
 the `quay.io/openshift-release-dev`.
 
-This is the kind of thing that a RHTAP user might want to do based on what
+This is the kind of thing that a Konflux user might want to do based on what
 security policies they decide are appopriate for their situation.
 
 First, let's take a look at how that rule works. The documentation is

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -1,9 +1,9 @@
 
-= Getting started with Enterprise Contract & Red Hat Trusted Application Pipeline
+= Getting started with Enterprise Contract & Konflux CI
 
 == Creating an application
 
-If you don't already have an application defined in RHTAP, follow the
+If you don't already have an application defined in Konflux, follow the
 link:https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/getting-started/get-started/[getting
 started guide here]. Once that's done you should have an application with at least one component.
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -2,7 +2,8 @@
 = Enterprise Contract User Guide
 
 This documentation will describe how to use Enterprise Contract, particularly
-with link:https://developers.redhat.com/products/trusted-software-supply-chain/overview[Red Hat Trusted Application Pipeline].
+with [Konflux CI](https://github.com/konflux-ci), formerly
+[Red Hat App Studio](https://github.com/redhat-appstudio).
 
 See also the
 link:https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/[App

--- a/modules/ROOT/pages/reproducing-an-rhtap-report.adoc
+++ b/modules/ROOT/pages/reproducing-an-rhtap-report.adoc
@@ -1,8 +1,8 @@
-= Reproducing an RHTAP Enterprise Contract report locally
+= Reproducing a Konflux Enterprise Contract report locally
 
 This requires that you installed `ec` locally as described in
 xref:cli.adoc[Command line EC], and that you have at least one Enterprise
-Contract integration test pipeline run in your RHTAP environment.
+Contract integration test pipeline run in your Konflux environment.
 
 include::partial$oc_login.adoc[]
 

--- a/modules/ROOT/pages/slsa.adoc
+++ b/modules/ROOT/pages/slsa.adoc
@@ -1,20 +1,20 @@
 
-= Red Hat Trusted Application Pipeline, Enterprise Contract, and SLSA
+= Konflux CI, Enterprise Contract, and SLSA
 
 .Overview
 ****
 
-Red Hat Trusted Application Pipeline is a build and CI/CD system
+Konflux CI is a build and CI/CD system
 that aims to meet or exceed https://slsa.dev/spec/v1.0/levels[SLSA Build L3 (v1.0)].
 Enterprise Contract is an
 https://slsa.dev/spec/v1.0/verifying-artifacts[artifact verifier] and
-customizable policy checker designed to be easily integrated with RHTAP's CI/CD
+customizable policy checker designed to be easily integrated with Konflux's CI/CD
 workflows.
 
-A lot of the default policies created for RHTAP and enforced by EC are closely
+A lot of the default policies created for Konflux and enforced by EC are closely
 related to SLSA requirements, based on both the recent SLSA v1.0, and the older
 SLSA v0.1 specification. In this documentation we'll describe in more detail
-how RHTAP and EC work together to provide a high standard of supply chain
+how Konflux and EC work together to provide a high standard of supply chain
 security, informed and guided by the link:https://slsa.dev/[SLSA
 specifications].
 
@@ -25,7 +25,7 @@ specifications].
 === SLSA requirements verified explicitly by Enterprise Contract
 
 Enterprise Contract comes with a set of policy rules designed for use with
-RHTAP. Using EC to verify that a build passes all the checks defined by the
+Konflux. Using EC to verify that a build passes all the checks defined by the
 policy provides a high level of confidence that the build was built securely
 and can be trusted.
 
@@ -37,28 +37,28 @@ Many of the policy rules are linked to specific SLSA requirements, for example:
 
 a| https://slsa.dev/spec/v0.1/requirements#scripted-build[Scripted build (v0.1)]
 a| xref:ec-policies:ROOT:release_policy.adoc#slsa_build_scripted_build__build_script_used[Build task contains steps]
-a| RHTAP uses link:https://tekton.dev/[Tekton] so knowing that is enough to consider this requirement satisfied, however this specific
+a| Konflux uses link:https://tekton.dev/[Tekton] so knowing that is enough to consider this requirement satisfied, however this specific
 rule confirms it explicitly for each build. The rule asserts that the attestation includes details about the pipeline run that created the build,
 that the specific task run that pushed the image is identifiable, and that information about each steps in that task run are present.
 
 a| https://slsa.dev/spec/v0.1/requirements#build-service[Build service (v0.1)]
 a| xref:ec-policies:ROOT:release_policy.adoc#slsa_build_build_service__slsa_builder_id_found[SLSA Builder ID found]
 a| This check aims to confirm the basic requirement from the v0.1 SLSA spec that the build ran on a build service. Once again, any build created
-by RHTAP is expected to meet this requirement, but the rule confirms this by verifying that that a builder is present in the SLSA attestation. The SLSA
+by Konflux is expected to meet this requirement, but the rule confirms this by verifying that that a builder is present in the SLSA attestation. The SLSA
 Builder ID is also key part of the link:https://slsa.dev/spec/v1.0/verifying-artifacts#step-1-check-slsa-build-level[Verifying Artifacts] process
 described in SLSA v1.0.
 
 a| https://slsa.dev/spec/v0.1/requirements#hermetic[Hermetic Builds (v0.1)]
 a| xref:ec-policies:ROOT:release_policy.adoc#hermetic_build_task__build_task_hermetic[Build task called with hermetic param set]
 a| This rule verifies that the build task was called with a particular parameter specifying the build should be done hermeticly. This rule is specific
-to RHTAP's task definitions, since EC isn't able to explicitly confirm that the build was indeed hermetic. But, when combined with the strictest
+to Konflux's task definitions, since EC isn't able to explicitly confirm that the build was indeed hermetic. But, when combined with the strictest
 "acceptable task bundles" rule, and a trustable source for the task definition, we can use the rule to ensure that only builds performed hermeticly can
 be released.
 
 a| https://slsa.dev/spec/v1.0/verifying-artifacts#step-1-check-slsa-build-level[Verifying Artifacts (v1.0)]
 a| xref:ec-policies:ROOT:release_policy.adoc#slsa_build_build_service__slsa_builder_id_accepted[SLSA Builder ID is known and accepted]
 a| The verification process described in the SLSA v1.0 spec includes a check to confirm the builder id matches what is
-expected. This rule will fail if an unexpected builder id is found in the SLSA attestation. (For RHTAP currently the builder id
+expected. This rule will fail if an unexpected builder id is found in the SLSA attestation. (For Konflux currently the builder id
 is the default used by Tekton Chains, though this may change in the future.)
 
 a| https://slsa.dev/spec/v1.0/threats#f-upload-modified-package[Threat (G) - Upload modified package],
@@ -69,13 +69,13 @@ signature can't be verified for any reason, a failure will be reported. There ar
 but EC will happily do it for you.
 
 There is also experimental support in EC for validating signatures for images signed keylessly
-using https://docs.sigstore.dev/fulcio/overview/[Sigstore Fulcio], though RHTAP currently uses long-lived
+using https://docs.sigstore.dev/fulcio/overview/[Sigstore Fulcio], though Konflux currently uses long-lived
 signing keys to sign images and attestations.
 
 a| https://slsa.dev/spec/v1.0/verifying-artifacts[Verifying Artifacts (v1.0)]
 a| xref:ec-policies:ROOT:release_policy.adoc#builtin_attestation__signature_check[Attestation signature check passed]
 a| As well as verifying the image signature, EC also verifies the signature of the attestation, which is an important part of the artifact
-verification process. For RHTAP the same key is used to sign the attestation and the image itself. As mentioned above, there is experimental
+verification process. For Konflux the same key is used to sign the attestation and the image itself. As mentioned above, there is experimental
 support for verifying keylessly signed attestations.
 
 a| https://slsa.dev/spec/v1.0/verifying-artifacts#step-1-check-slsa-build-level[Verifying Artifacts (v1.0)]
@@ -92,7 +92,7 @@ and will fail if the predicate type is found to be any other value.
 
 a| https://slsa.dev/spec/v1.0/verifying-artifacts#step-1-check-slsa-build-level[Verifying Artifacts (v1.0)]
 a| xref:ec-policies:ROOT:release_policy.adoc#provenance_materials__git_clone_source_matches_provenance[Git clone source matches materials provenance]
-a| This is a good sanity check related to artifact verification that isn't specifically mentioned in the SLSA guidelines. In RHTAP build pipelines the
+a| This is a good sanity check related to artifact verification that isn't specifically mentioned in the SLSA guidelines. In Konflux build pipelines the
 git clone task provides information about the git repo and the commit sha used. This rule confirms that the url and the commit sha from the git clone
 task match what appears in the "materials" provenance.
 
@@ -100,39 +100,39 @@ task match what appears in the "materials" provenance.
 
 === SLSA requirements not explicitly verified by Enterprise Contract
 
-There are numerous SLSA Build requirements that are met by Red Hat Trusted
-Application Pipeline, but not explicitly verifiable with an Enterprise Contract
-policy rule. We won't go into depth in this document, but for example:
+There are numerous SLSA Build requirements that are met by Konflux CI, but not
+explicitly verifiable with an Enterprise Contract policy rule. We won't go
+into depth in this document, but for example:
 
 [cols="1,3"]
 |===
-|SLSA reference|RHTAP response
+|SLSA reference|Konflux response
 
 a| https://slsa.dev/spec/v1.0/levels#build-l2-hosted-build-platform[Build L2: Hosted build platform]
-a| Due to its design, its architecture, and operational management, the Red Hat Trusted Application
-Pipeline, meets these requirements implicitly. And, as we've seen above, the Enterprise Contract
+a| Due to its design, its architecture, and operational management, Konflux CI,
+meets these requirements implicitly. And, as we've seen above, the Enterprise Contract
 can be used to verify the authenticity of the signed provenances.
 
 a| https://slsa.dev/spec/v1.0/levels#build-l3-hardened-builds[Build L3: Hardened builds]
-a| For example, the RHTAP's Tekton environment prevents different build pipelines from influencing each
+a| For example, the Konflux's Tekton environment prevents different build pipelines from influencing each
 other, and has secure access polices and management practices for signing secrets and other credentials.
 
 |===
 
 ////
-In the future there may be some RHTAP system level docs addressing this in more detail.
-Linking to a general system overview of RHTAP would also be useful here also I think.
+In the future there may be some Konflux system level docs addressing this in more detail.
+Linking to a general system overview of Konflux would also be useful here also I think.
 ////
 
 == Notes and caveats
 
-Because EC was designed initially for use with RHTAP, and RHTAP uses Tekton
+Because EC was designed initially for use with Konflux, and Konflux uses Tekton
 CI/CD, many of the specific rules mentioned above are currently Tekton specific
 in that they use details about the Tekton pipeline run, which are currently
 made available in the SLSA attestation created by Tekton Chains.
 
 This is not a limitation of EC itself, but rather just an attribute of the
-xref:ec-policies:ROOT:release_policy.adoc[policies created for RHTAP] in their
+xref:ec-policies:ROOT:release_policy.adoc[policies created for Konflux] in their
 current state. In the future we're aiming to extract the Tekton specific rules from
 the general SLSA rules to make the rules more generally applicable. We expected
 that policy rules for build systems not based on Tekton and Tekton Chains could
@@ -143,12 +143,12 @@ https://www.openpolicyagent.org/docs/latest/policy-language/[OPA/Rego], it is
 able to be used for a wide range of purposes, e.g. to verify certain tests were
 run and passed, and to apply any business specific release policies. Browse the
 rules defined in xref:ec-policies:ROOT:release_policy.adoc[Policies] to see
-what other rules have been defined for use by RHTAP within Red Hat.
+what other rules have been defined for use by Konflux within Red Hat.
 
 == Conclusion
 
 Enterprise Contract can be used as a convenient and customizable SLSA artifact
-verifier. It's doing that now within RHTAP, and we think it's capable and
+verifier. It's doing that now within Konflux, and we think it's capable and
 flexible enough to become a part of other build systems where supply chain security
 is a priority.
 

--- a/modules/ROOT/partials/contents.adoc
+++ b/modules/ROOT/partials/contents.adoc
@@ -5,7 +5,7 @@
 * How-to guides
 ** xref:cosign.adoc[Using Cosign]
 ** xref:cli.adoc[Command line EC]
-** xref:reproducing-an-rhtap-report.adoc[Reproducing an RHTAP EC report locally]
+** xref:reproducing-an-rhtap-report.adoc[Reproducing a Konflux EC report locally]
 ** xref:custom-config.adoc[Using custom configuration]
 ** xref:custom-data.adoc[Using custom data]
 ** xref:hitchhikers-guide.adoc[Hitchhiker's Guide to EC]

--- a/modules/ROOT/partials/oc_login.adoc
+++ b/modules/ROOT/partials/oc_login.adoc
@@ -1,3 +1,3 @@
-Follow the procedure for accessing the RHTAP cluster via the `oc` command line
+Follow the procedure for accessing the Konflux cluster via the `oc` command line
 client link:https://redhat-appstudio.github.io/docs.appstudio.io/Documentation/main/getting-started/getting_started_in_cli/[as
 described here].


### PR DESCRIPTION
Note that the thing that was previously called RHTAP, is almost, but not entirely the same as the thing that is now called Konflux, so there may be further revisions needed. This commit is mostly just an unsophisticated search and replace.

(We might also want to consider splitting Konflux specific docs into another location but that can come later.)

Ref: [EC-378](https://issues.redhat.com/browse/EC-378)