### PR TITLE
Remove references to Red Hat App Studio

### DIFF
--- a/modules/ROOT/pages/cosign.adoc
+++ b/modules/ROOT/pages/cosign.adoc
@@ -3,8 +3,7 @@
 
 In this section we'll provide examples showing how to use cosign to verify
 signatures and attestations for builds created by [Konflux
-CI](https://github.com/konflux-ci), formerly [Red Hat App
-Studio](https://github.com/redhat-appstudio).
+CI](https://github.com/konflux-ci).
 
 For detailed information on Cosign refer to the
 link:https://docs.sigstore.dev/cosign/overview/[official documentation].

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -2,8 +2,7 @@
 = Enterprise Contract User Guide
 
 This documentation will describe how to use Enterprise Contract, particularly
-with [Konflux CI](https://github.com/konflux-ci), formerly
-[Red Hat App Studio](https://github.com/redhat-appstudio).
+with [Konflux CI](https://github.com/konflux-ci).
 
 See also the link:https://konflux-ci.dev/docs/[Konflux-CI Documentation].
 


### PR DESCRIPTION
The name is deprecated. We don't really need to call out that Konflux had a different name.

Ref: EC-450