### PR TITLE
Fix incorrect app install id

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -19,7 +19,7 @@ jobs:
         include:
           - APP_INSTALL_ID: 29980719
             REPOSITORY: enterprise-contract/enterprise-contract.github.io
-          - APP_INSTALL_ID: 29980719
+          - APP_INSTALL_ID: 59973090
             REPOSITORY: conforma/conforma.github.io
     steps:
       - name: Harden Runner


### PR DESCRIPTION
A fixup for #159. I didn't understand that the install id is unique to the org and app, not just the app.