### PR TITLE
Remove old install id

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,8 +18,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - APP_INSTALL_ID: 29980719
-            REPOSITORY: enterprise-contract/enterprise-contract.github.io
           - APP_INSTALL_ID: 59973090
             REPOSITORY: conforma/conforma.github.io
     steps:


### PR DESCRIPTION
The CI breaks when it tries to use it, so it needs to be removed.

Ref: https://issues.redhat.com/browse/EC-1081